### PR TITLE
ref: use defaults for common `shell` value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,19 +7,20 @@ inputs:
   force:
     description: Force a release even when there are release-blockers (optional)
     required: false
+defaults:
+  run:
+    shell: bash
 runs:
   using: 'composite'
   steps:
     - id: killswitch
       name: Check release blockers
-      shell: bash
       run: |
         if [[ -z '${{ inputs.force }}' ]] && curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?state=open&labels=release-blocker" | grep -Pzvo '\[[\s\n\r]*\]'; then
           echo "Open release-blocking issues found, cancelling release...";
           curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ github.token }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel;
         fi
     - name: Determine version
-      shell: bash
       run: |
         if [[ -n '${{ inputs.version }}' ]]; then
           echo 'RELEASE_VERSION=${{ inputs.version }}' >> $GITHUB_ENV;
@@ -32,7 +33,6 @@ runs:
           echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
         fi
     - name: Set git user to getsentry-bot
-      shell: bash
       run: |
         echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
         echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;


### PR DESCRIPTION
Just learned about this: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#defaultsrun
