### PR TITLE
feat: Run Craft outside of Docker and bundle publish request 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   version:
     description: Version to release (optional)
     required: false
+  calver:
+    description: Use automatic CalVer versioning
+    required: true
+    default: false
   force:
     description: Force a release even when there are release-blockers (optional)
     required: false
@@ -28,13 +32,16 @@ runs:
       run: |
         if [[ -n '${{ inputs.version }}' ]]; then
           echo 'RELEASE_VERSION=${{ inputs.version }}' >> $GITHUB_ENV;
-        else
+        elif [[ '${{ inputs.calver }}' = 'true' ]]
           DATE_PART=$(date +'%y.%-m')
           declare -i PATCH_VERSION=0
           while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
             PATCH_VERSION+=1
           done
           echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
+        else
+          echo "You need to provide a version to release.";
+          exit 1;
         fi
     - name: Set git user to getsentry-bot
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Release prep'
-description: 'Common setup for craft/prepare'
+name: "Release prep"
+description: "Common setup for craft/prepare"
 inputs:
   version:
     description: Version to release (optional)
@@ -7,8 +7,11 @@ inputs:
   force:
     description: Force a release even when there are release-blockers (optional)
     required: false
+  craft_version:
+    description: The craft version to use, defaults to latest
+
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - id: killswitch
       name: Check release blockers
@@ -37,3 +40,24 @@ runs:
         echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
         echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
         echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;
+    - name: Craft Prepare
+      run: npx @sentry/craft@${{ inputs.craft_version }} prepare --no-input "${{ env.RELEASE_VERSION }}"
+      env:
+        # TODO: Remove this
+        GITHUB_API_TOKEN: ${{ github.token }}
+    - name: Get Release Branch
+      id: release-branch
+      run: echo "::set-output name=ref::$(git rev-parse --symbolic-full-name @{-1})"
+    - name: Request publish
+      if: success()
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{ secrets.GH_RELEASE_PAT }}
+        script: |
+          const repoInfo = context.repo;
+          await github.issues.create({
+            owner: repoInfo.owner,
+            repo: 'publish',
+            title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
+            body: `Requested by: @${context.actor}\nView diff at: https://github.com/${repoInfo.owner}/${repoInfo.repo}/compare/${{ steps.release-branch.outputs.ref }}`
+          });

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
   craft_version:
     description: The craft version to use, defaults to "latest" (optional)
-    required: false
+    required: true
     default: latest
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Release prep"
+name: "Prepare Release"
 description: "Common setup for craft/prepare"
 inputs:
   version:
@@ -8,7 +8,9 @@ inputs:
     description: Force a release even when there are release-blockers (optional)
     required: false
   craft_version:
-    description: The craft version to use, defaults to latest
+    description: The craft version to use, defaults to "latest" (optional)
+    required: false
+    default: latest
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -45,11 +45,13 @@ runs:
     - name: Craft Prepare
       run: npx @sentry/craft@${{ inputs.craft_version }} prepare --no-input "${{ env.RELEASE_VERSION }}"
       env:
-        # TODO: Remove this
+        # TODO: Remove this when the latest version of craft is released
         GITHUB_API_TOKEN: ${{ github.token }}
-    - name: Get Release Branch
-      id: release-branch
-      run: echo "::set-output name=ref::$(git rev-parse --symbolic-full-name @{-1})"
+    - name: Get Release Git Info
+      id: release-git-info
+      run: |
+        echo "::set-output name=branch::$(git rev-parse --symbolic-full-name @{-1})"
+        echo "::set-output name=sha::$(git rev-parse @{-1})"
     - name: Request publish
       if: success()
       uses: actions/github-script@v3
@@ -61,5 +63,11 @@ runs:
             owner: repoInfo.owner,
             repo: 'publish',
             title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
-            body: `Requested by: @${context.actor}\nView diff at: https://github.com/${repoInfo.owner}/${repoInfo.repo}/compare/${{ steps.release-branch.outputs.ref }}`
+            body: [
+              `Requested by: @${context.actor}`
+              ``,
+              `Quick links:`,
+              `- [View changes](https://github.com/${repoInfo.owner}/${repoInfo.repo}/compare/${{ steps.release-git-info.outputs.branch }})`,
+              `- [View check runs](https://github.com/${repoInfo.owner}/${repoInfo.repo}/commit/${{ steps.release-git-info.outputs.sha }}/checks/)`,
+            ].join('\n'),
           });


### PR DESCRIPTION
This PR bundles the 'Craft Prepare' and 'Request publish' steps by leveraging the fact that Craft can be run outside of the Docker image, w/o the Craft action as done in getsentry/sentry-javascript#3130. It also improves the automatically crated publish request issue's body by adding the comparison link, normally produced by Craft and tagging the initiator/requester of the release.

~~This PR **SHOULD NOT** be merged before pinning all dependents of `action-prepare-release` as it is very likely to break them.~~

This action now requires `action/checkout` to be run beforehand.