### PR TITLE
fix(compare): Compare link should use `tag_name`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       run: |
         echo "::set-output name=branch::$(git rev-parse --symbolic-full-name @{-1})"
         echo "::set-output name=sha::$(git rev-parse @{-1})"
-        echo "::set-output name=last::$(gh api repos/:owner/:repo/releases/latest | jq -r .name)"
+        echo "::set-output name=last::$(gh api repos/:owner/:repo/releases/latest | jq -r .tag_name)"
     - name: Request publish
       shell: bash
       run: |


### PR DESCRIPTION
We were using the latest 'release name' instead of the latest 'release _tag_ name' when generating the compare link. These are usually the same but for some cases, like getsentry/publish#90, they can be different and break the MD syntax along with the link.
