### PR TITLE
fix: Fix errors introduced in previous 2 PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,4 +110,4 @@ runs:
         ### Targets
         ${{ steps.craft.outputs.targets }}
         "
-        gh issue create -R "$GITHUB_REPOSITORY_OWNER/publish" --title "$ISSUE_TITLE" --body "$body"
+        gh issue create -R "$GITHUB_REPOSITORY_OWNER/publish" --title "$title" --body "$body"

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       shell: bash
       run: |
         npx_cache=$(mktemp -d -t .npx_cache_XXX)
-        function craft() { return npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
+        function craft() { npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
         export -f craft
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
       shell: bash
       run: |
         # TODO(byk): Remove these lines when gh is updated in GHA
-        curl -L https://github.com/cli/cli/releases/download/v1.8.0/gh_1.8.0_linux_amd64.deb > $TMPDIR/gh.deb
+        curl -L 'https://github.com/cli/cli/releases/download/v1.8.0/gh_1.8.0_linux_amd64.deb' > $TMPDIR/gh.deb
         sudo dpkg -i $TMPDIR/gh.deb
 
         if [[ '${{ inputs.path }}' == '.' ]]; then

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       id: craft
       shell: bash
       run: |
-        npx_cache=$(mktemp -d -t $GITHUB_WORKSPACE/.npx_cache)
+        npx_cache=$(mktemp -d -t .npx_cache)
         function craft() { return npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
         export -f craft
         cd '${{ inputs.path }}'

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         else
           subdirectory='/${{ inputs.path }}';
         fi
-        echo "ISSUE_TITLE=publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION" >> $GITHUB_ENV
+        echo "ISSUE_TITLE='publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION'" >> $GITHUB_ENV
     - name: Check existing publish requests
       id: existing-request
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,6 @@ runs:
     - name: Request publish
       shell: bash
       run: |
-        set -x
         if [[ '${{ inputs.path }}' == '.' ]]; then
           subdirectory='';
         else
@@ -89,6 +88,7 @@ runs:
         fi
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
+        gh --version
         issue_count=$(gh issue list -S "'$title' in:title" | wc -l)
         if [[ "$issue_count" == '0' ]]; then
           echo "There's already an open publish request, skipped issue creation.";

--- a/action.yml
+++ b/action.yml
@@ -60,11 +60,11 @@ runs:
         cd $craft_dir
         npm install @sentry/craft@${{ inputs.craft_version }}
         echo "$craft_dir/node_modules/.bin" >> $GITHUB_PATH
+        cd $GITHUB_WORKSPACE
     - name: Craft Prepare
       id: craft
       shell: bash
       run: |
-        set +x
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
@@ -73,7 +73,6 @@ runs:
       id: existing-request
       shell: bash
       run: |
-        set +x
         issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         echo $(craft targets)
-        targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
+        targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
         echo "::set-output name=targets::$targets"
     - name: Get Release Git Info
       id: release-git-info

--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,17 @@ runs:
         echo "GIT_COMMITTER_NAME=getsentry-bot" >> $GITHUB_ENV;
         echo "GIT_AUTHOR_NAME=getsentry-bot" >> $GITHUB_ENV;
         echo "EMAIL=bot@getsentry.com" >> $GITHUB_ENV;
+    - name: Install Craft
+      shell: bash
+      run: |
+        craft_dir=$(mktemp -d -t .craft_XXX)
+        cd $craft_dir
+        npm install @sentry/craft@${{ inputs.craft_version }}
+        echo "$craft_dir/node_modules/.bin" >> $GITHUB_PATH
     - name: Craft Prepare
       id: craft
       shell: bash
       run: |
-        npx_cache=$(mktemp -d -t .npx_cache_XXX)
-        function craft() { npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
-        export -f craft
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')

--- a/action.yml
+++ b/action.yml
@@ -66,19 +66,11 @@ runs:
       env:
         CRAFT_LOG_LEVEL: WARN
       run: |
-        set -x
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         echo $(craft targets)
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
         echo "::set-output name=targets::$targets"
-    - name: Check existing publish requests
-      id: existing-request
-      shell: bash
-      run: |
-        set -x
-        issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
-        echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info
       id: release-git-info
       shell: bash
@@ -89,6 +81,7 @@ runs:
     - name: Request publish
       shell: bash
       run: |
+        set -x
         if [[ '${{ inputs.path }}' == '.' ]]; then
           subdirectory='';
         else

--- a/action.yml
+++ b/action.yml
@@ -60,19 +60,21 @@ runs:
         cd $craft_dir
         npm install @sentry/craft@${{ inputs.craft_version }}
         echo "$craft_dir/node_modules/.bin" >> $GITHUB_PATH
-        cd $GITHUB_WORKSPACE
     - name: Craft Prepare
       id: craft
       shell: bash
       run: |
+        set -x
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
+        echo $(craft targets)
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
         echo "::set-output name=targets::$targets"
     - name: Check existing publish requests
       id: existing-request
       shell: bash
       run: |
+         set -x
         issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info

--- a/action.yml
+++ b/action.yml
@@ -57,8 +57,10 @@ runs:
       id: craft
       shell: bash
       run: |
+        npx_cache=$(mktemp -d -t $GITHUB_WORKSPACE/.npx_cache)
+        function craft() { return npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
+        export -f craft
         cd '${{ inputs.path }}'
-        npm install -g @sentry/craft@${{ inputs.craft_version }}
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
         echo "::set-output name=targets::$targets"

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,7 @@ runs:
       id: craft
       shell: bash
       run: |
+        set +x
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
@@ -72,6 +73,7 @@ runs:
       id: existing-request
       shell: bash
       run: |
+        set +x
         issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info

--- a/action.yml
+++ b/action.yml
@@ -82,14 +82,14 @@ runs:
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info
       id: release-git-info
-      if: steps.existing-request.outputs.count == '0'
+      if: ${{ steps.existing-request.outputs.count == '0' }}
       shell: bash
       run: |
         echo "::set-output name=branch::$(git rev-parse --symbolic-full-name @{-1})"
         echo "::set-output name=sha::$(git rev-parse @{-1})"
         echo "::set-output name=last::$(gh api repos/:owner/:repo/releases/latest | jq -r .tag_name)"
     - name: Request publish
-      if: steps.existing-request.outputs.count == '0'
+      if: ${{ steps.existing-request.outputs.count == '0' }}
       shell: bash
       run: |
         body="Requested by: @$GITHUB_ACTOR

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       id: craft
       shell: bash
       run: |
-        npx_cache=$(mktemp -d -t .npx_cache)
+        npx_cache=$(mktemp -d -t .npx_cache_XXX)
         function craft() { return npx --cache $npx_cache @sentry/craft@${{ inputs.craft_version }} "$@"; }
         export -f craft
         cd '${{ inputs.path }}'

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
       id: existing-request
       shell: bash
       run: |
-         set -x
+        set -x
         issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info

--- a/action.yml
+++ b/action.yml
@@ -62,18 +62,6 @@ runs:
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
         echo "::set-output name=targets::$targets"
-      env:
-        # TODO: Remove this when the latest version of craft is released
-        GITHUB_API_TOKEN: ${{ github.token }}
-    - name: Set issue title for publish request
-      shell: bash
-      run: |
-        if [[ '${{ inputs.path }}' == '.' ]]; then
-          subdirectory='';
-        else
-          subdirectory='/${{ inputs.path }}';
-        fi
-        echo "ISSUE_TITLE='publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION'" >> $GITHUB_ENV
     - name: Check existing publish requests
       id: existing-request
       shell: bash
@@ -82,16 +70,27 @@ runs:
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info
       id: release-git-info
-      if: ${{ steps.existing-request.outputs.count == '0' }}
       shell: bash
       run: |
         echo "::set-output name=branch::$(git rev-parse --symbolic-full-name @{-1})"
         echo "::set-output name=sha::$(git rev-parse @{-1})"
         echo "::set-output name=last::$(gh api repos/:owner/:repo/releases/latest | jq -r .tag_name)"
     - name: Request publish
-      if: ${{ steps.existing-request.outputs.count == '0' }}
       shell: bash
       run: |
+        if [[ '${{ inputs.path }}' == '.' ]]; then
+          subdirectory='';
+        else
+          subdirectory='/${{ inputs.path }}';
+        fi
+
+        title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
+        issue_count=$(gh issue list -S "'$title' in:title" | wc -l)
+        if [[ "$issue_count" == '0' ]]; then
+          echo "There's already an open publish request, skipped issue creation.";
+          exit 0;
+        fi
+
         body="Requested by: @$GITHUB_ACTOR
 
         Quick links:

--- a/action.yml
+++ b/action.yml
@@ -60,16 +60,25 @@ runs:
         cd '${{ inputs.path }}'
         npm install -g @sentry/craft@${{ inputs.craft_version }}
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
-        targets=$(craft targets | jq -r '.[]|"  [ ] \\(.)"')
+        targets=$(craft targets | jq -r '.[]|"  [ ] \(.)"')
         echo "::set-output name=targets::$targets"
       env:
         # TODO: Remove this when the latest version of craft is released
         GITHUB_API_TOKEN: ${{ github.token }}
+    - name: Set issue title for publish request
+      shell: bash
+      run: |
+        if [[ '${{ inputs.path }}' == '.' ]]; then
+          subdirectory='';
+        else
+          subdirectory='/${{ inputs.path }}';
+        fi
+        echo "ISSUE_TITLE=publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION" >> $GITHUB_ENV
     - name: Check existing publish requests
       id: existing-request
       shell: bash
       run: |
-        issue_count=$(gh issue list -S "'publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION' in:title" | wc -l)
+        issue_count=$(gh issue list -S "'$ISSUE_TITLE' in:title" | wc -l)
         echo "::set-output name=count::$issue_count"
     - name: Get Release Git Info
       id: release-git-info
@@ -83,12 +92,6 @@ runs:
       if: steps.existing-request.outputs.count == '0'
       shell: bash
       run: |
-        if [[ '${{ inputs.path }}' == '.' ]]; then
-          subdirectory='';
-        else
-          subdirectory='/${{ inputs.path }}';
-        fi
-        title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
         body="Requested by: @$GITHUB_ACTOR
 
         Quick links:
@@ -100,4 +103,4 @@ runs:
         ### Targets
         ${{ steps.craft.outputs.targets }}
         "
-        gh issue create -R "$GITHUB_REPOSITORY_OWNER/publish" --title "$title" --body "$body"
+        gh issue create -R "$GITHUB_REPOSITORY_OWNER/publish" --title "$ISSUE_TITLE" --body "$body"

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
         issue_count=$(gh issue list -S "'$title' in:title" | wc -l)
-        if [[ "$issue_count" == '0' ]]; then
+        if [[ "$issue_count" != '0' ]]; then
           echo "There's already an open publish request, skipped issue creation.";
           exit 0;
         fi

--- a/action.yml
+++ b/action.yml
@@ -82,8 +82,9 @@ runs:
       shell: bash
       run: |
         # TODO(byk): Remove these lines when gh is updated in GHA
-        curl -L 'https://github.com/cli/cli/releases/download/v1.8.0/gh_1.8.0_linux_amd64.deb' > $TMPDIR/gh.deb
-        sudo dpkg -i $TMPDIR/gh.deb
+        curl -L 'https://github.com/cli/cli/releases/download/v1.8.0/gh_1.8.0_linux_amd64.deb' > gh.deb
+        sudo dpkg -i gh.deb
+        rm gh.deb
 
         if [[ '${{ inputs.path }}' == '.' ]]; then
           subdirectory='';

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,6 @@ runs:
       run: |
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
-        echo $(craft targets)
         targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
         echo "::set-output name=targets::$targets"
     - name: Get Release Git Info

--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
         fi
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
-        issue_count=$(gh issue list -S "'$title' in:title" | wc -l)
+        issue_count=$(gh -R $GITHUB_REPOSITORY_OWNER/publish issue list -S "'$title' in:title" | wc -l)
         if [[ "$issue_count" != '0' ]]; then
           echo "There's already an open publish request, skipped issue creation.";
           exit 0;

--- a/action.yml
+++ b/action.yml
@@ -82,8 +82,8 @@ runs:
       shell: bash
       run: |
         # TODO(byk): Remove these lines when gh is updated in GHA
-        sudo apt update
-        sudo apt install gh
+        curl -L https://github.com/cli/cli/releases/download/v1.8.0/gh_1.8.0_linux_amd64.deb > $TMPDIR/gh.deb
+        sudo dpkg -i $TMPDIR/gh.deb
 
         if [[ '${{ inputs.path }}' == '.' ]]; then
           subdirectory='';

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,10 @@ runs:
     - name: Request publish
       shell: bash
       run: |
+        # TODO(byk): Remove these lines when gh is updated in GHA
+        sudo apt update
+        sudo apt install gh
+
         if [[ '${{ inputs.path }}' == '.' ]]; then
           subdirectory='';
         else
@@ -88,7 +92,6 @@ runs:
         fi
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
-        gh --version
         issue_count=$(gh issue list -S "'$title' in:title" | wc -l)
         if [[ "$issue_count" == '0' ]]; then
           echo "There's already an open publish request, skipped issue creation.";

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,8 @@ runs:
     - name: Craft Prepare
       id: craft
       shell: bash
+      env:
+        CRAFT_LOG_LEVEL: WARN
       run: |
         set -x
         cd '${{ inputs.path }}'


### PR DESCRIPTION
The target creation snippet had an extra `\`, and the duplicate issue checker was referencing a non-existent `$subdirectory` variable due to a c/p error.
