### PR TITLE
fix(targets): Use newline escaping for targets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,8 @@ runs:
       run: |
         cd '${{ inputs.path }}'
         craft prepare --no-input "${{ env.RELEASE_VERSION }}"
-        targets=$(craft targets)
+        targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
+        targets="${targets//$'\n'/'%0A'}"
         echo "::set-output name=targets::$targets"
     - name: Get Release Git Info
       id: release-git-info
@@ -98,7 +99,6 @@ runs:
           exit 0;
         fi
 
-        targets=$(echo '${{ steps.craft.outputs.targets }}' | jq -r '.[]|" - [ ] \(.)"')
         body="Requested by: @$GITHUB_ACTOR
 
         Quick links:
@@ -108,6 +108,6 @@ runs:
         Assign the **accepted** label to this issue to approve the release.
 
         ### Targets
-        $targets
+        ${{ steps.craft.outputs.targets }}
         "
         gh issue create -R "$GITHUB_REPOSITORY_OWNER/publish" --title "$title" --body "$body"


### PR DESCRIPTION
The previous commit, 44a8c6e4e169cda7e4c95d434e7b388e2c7c1fe7 did not fix the issue as Craft's JSON output itself has new lines in it. This patch just uses the multi-line escaping recommended at https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=byk
