### PR TITLE
feat: Use craft single-file binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,8 +57,8 @@ runs:
       shell: bash
       run: |
         craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
-        curl -sL -o /usr/bin/curl "$craft_url"
-        chmod +x /usr/bin/curl
+        curl -sL -o /usr/local/bin/curl "$craft_url"
+        chmod +x /usr/local/bin/curl
     - name: Craft Prepare
       id: craft
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       shell: bash
       run: |
         craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
-        curl -sL -o /usr/local/bin/curl "$craft_url"
+        sudo curl -sL -o /usr/local/bin/curl "$craft_url"
         sudo chmod +x /usr/local/bin/curl
     - name: Craft Prepare
       id: craft

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
     - name: Install Craft
       shell: bash
       run: |
-        craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/${{ inputs.craft_version }}/latest | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
+        craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
         curl -sL -o /usr/bin/curl "$craft_url"
         chmod +x /usr/bin/curl
     - name: Craft Prepare

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       run: |
         craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
         curl -sL -o /usr/local/bin/curl "$craft_url"
-        chmod +x /usr/local/bin/curl
+        sudo chmod +x /usr/local/bin/curl
     - name: Craft Prepare
       id: craft
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -56,10 +56,9 @@ runs:
     - name: Install Craft
       shell: bash
       run: |
-        craft_dir=$(mktemp -d -t .craft_XXX)
-        cd $craft_dir
-        npm install @sentry/craft@${{ inputs.craft_version }}
-        echo "$craft_dir/node_modules/.bin" >> $GITHUB_PATH
+        craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/${{ inputs.craft_version }}/latest | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
+        curl -sL -o /usr/bin/curl "$craft_url"
+        chmod +x /usr/bin/curl
     - name: Craft Prepare
       id: craft
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -57,8 +57,8 @@ runs:
       shell: bash
       run: |
         craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
-        sudo curl -sL -o /usr/local/bin/curl "$craft_url"
-        sudo chmod +x /usr/local/bin/curl
+        sudo curl -sL -o /usr/local/bin/craft "$craft_url"
+        sudo chmod +x /usr/local/bin/craft
     - name: Craft Prepare
       id: craft
       shell: bash


### PR DESCRIPTION
This switches from using `npm` to install `craft` to directly downloading the single-file binary. This should speed up the craft install and reduce the complexity around installing it (no more temp dir or path modification etc.)
