### PR TITLE
Fix escaping of #retract comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
         - [View check runs](https://github.com/$GITHUB_REPOSITORY/commit/${{ steps.release-git-info.outputs.sha }}/checks/)
 
         Assign the **accepted** label to this issue to approve the release.
-        Leave the `#retract` comment under this issue to retract the release (original issuer only).
+        Leave the \`#retract\` comment under this issue to retract the release (original issuer only).
 
         ### Targets
 


### PR DESCRIPTION
As this is a bash script, backticks are interpreted as a command, making their content missing, eg. https://github.com/getsentry/publish/issues/887#issue-1158702634