### PR TITLE
use the previous tag from git history rather than github

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,9 +80,9 @@ runs:
       id: release-git-info
       shell: bash
       run: |
-        echo "branch=$(git rev-parse --symbolic-full-name @{-1})" >> "$GITHUB_OUTPUT"
-        echo "sha=$(git rev-parse @{-1})" >> "$GITHUB_OUTPUT"
-        echo "last=$(gh api repos/:owner/:repo/releases/latest | jq -r .tag_name)" >> "$GITHUB_OUTPUT"
+        echo "branch=$(git rev-parse --symbolic-full-name HEAD)" >> "$GITHUB_OUTPUT"
+        echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        echo "last=$(git rev-parse --verify "$(git describe --tags --abbrev=0)" || echo HEAD)" >> "$GITHUB_OUTPUT"
     - name: Request publish
       shell: bash
       run: |


### PR DESCRIPTION
from checking out a release branch:

```bash
GITHUB_OUTPUT=output
git checkout origin/HEAD -b release-whatever
git commit --allow-empty -m test
echo "branch=$(git rev-parse --symbolic-full-name HEAD)" >> "$GITHUB_OUTPUT"
echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
echo "last=$(git rev-parse --verify "$(git describe --tags --abbrev=0)" || echo HEAD)" >> "$GITHUB_OUTPUT"
cat "$GITHUB_OUTPUT"
```

```console
$ bash -x t.sh 
+ GITHUB_OUTPUT=output
+ git checkout origin/HEAD -b release-whatever
Branch 'release-whatever' set up to track remote branch 'main' from 'origin'.
Switched to a new branch 'release-whatever'
+ git commit --allow-empty -m test
[release-whatever 73e14d4] test
++ git rev-parse --symbolic-full-name HEAD
+ echo branch=refs/heads/release-whatever
++ git rev-parse HEAD
+ echo sha=73e14d4a3d408697a62d4cb76ee46dd3951c0a79
+++ git describe --tags --abbrev=0
++ git rev-parse --verify v1
+ echo last=b318692847c53c6bab9d22b09deef25c42a86beb
+ cat output
branch=refs/heads/release-whatever
sha=2009c6338cea2054455b7df91f91fa3121be133b
last=b318692847c53c6bab9d22b09deef25c42a86beb
branch=refs/heads/release-whatever
sha=73e14d4a3d408697a62d4cb76ee46dd3951c0a79
last=b318692847c53c6bab9d22b09deef25c42a86beb
```

and:

```console
$ git show --decorate b318692 | head -1
commit b318692847c53c6bab9d22b09deef25c42a86beb (tag: v1.5.2, tag: v1.5, tag: v1)
```