### PR TITLE
skip craft switching back to primary branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,8 @@ runs:
         cd '${{ inputs.path }}'
         # Ensure we have origin/HEAD set
         git remote set-head origin --auto
-        CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
+        # --rev is used to avoid craft checking out the primary branch afterwards
+        CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}" --rev "$(git rev-parse --symbolic-ref origin/HEAD)"
         targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
 
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings


### PR DESCRIPTION
this is admittedly a bit of a hack -- craft by default switches back to the main branch unless `--rev` is passed