### PR TITLE
ref: switch back to release branch for git info

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,8 @@ runs:
       id: release-git-info
       shell: bash
       run: |
+        # craft switches back to `main` but we want info on the release branch
+        git checkout -
         echo "branch=$(git rev-parse --symbolic-full-name HEAD)" >> "$GITHUB_OUTPUT"
         echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         echo "last=$(git rev-parse --verify "$(git describe --tags --abbrev=0)" || echo HEAD)" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -72,8 +72,7 @@ runs:
         cd '${{ inputs.path }}'
         # Ensure we have origin/HEAD set
         git remote set-head origin --auto
-        # --rev is used to avoid craft checking out the primary branch afterwards which can break links in the generated GitHub Issue
-        CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}" --rev "$(git rev-parse --symbolic-ref origin/HEAD)"
+        CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
         targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
 
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings


### PR DESCRIPTION
the original approach of preventing `craft` from switching did not work -- trying this approach instead