### PR TITLE
feat: Add option to use craft config from merge target branch to prepare release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,12 @@ runs:
         craft_url=$(curl -s https://api.github.com/repos/getsentry/craft/releases/${{ inputs.craft_version }} | jq -r '.assets[].browser_download_url | select(endswith("/craft"))')
         sudo curl -sL -o /usr/local/bin/craft "$craft_url"
         sudo chmod +x /usr/local/bin/craft
+    - name: Checkout merge target branch
+      if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
+      shell: bash
+      run: |
+        git fetch origin ${{ inputs.merge_target }}
+        git checkout ${{ inputs.merge_target }}
     - name: Craft Prepare
       id: craft
       shell: bash
@@ -77,6 +83,8 @@ runs:
         git remote set-head origin --auto
         CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
     - name: Checkout merge target branch
+      # We need to check out the merge target branch again because at the end of `craft prepare`
+      # craft checks out the default branch
       if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,6 @@ inputs:
     default: "."
   craft_config_from_merge_target:
     description: Use the craft config from the merge target branch. Defaults to the repository's default branch
-    required: true
     default: false
 
 runs:
@@ -78,7 +77,7 @@ runs:
         git remote set-head origin --auto
         CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
     - name: Checkout merge target branch
-      if: (inputs.craft_config_from_merge_target == 'true') && (inputs.merge_target)
+      if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
       shell: bash
       run: |
         git fetch origin ${{ inputs.merge_target }}

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: The path that Craft will run inside. Defaults to `.`
     required: true
     default: "."
+  craft_config_from_merge_target:
+    description: Use the craft config from the merge target branch. Defaults to the repository's default branch
+    required: true
+    default: false
 
 runs:
   using: "composite"
@@ -73,6 +77,18 @@ runs:
         # Ensure we have origin/HEAD set
         git remote set-head origin --auto
         CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
+    - name: Checkout merge target branch
+      if: (inputs.craft_config_from_merge_target == 'true') && (inputs.merge_target)
+      shell: bash
+      run: |
+        git fetch origin ${{ inputs.merge_target }}
+        git checkout ${{ inputs.merge_target }}
+    - name: Read Craft Targets
+      id: craft-targets
+      shell: bash
+      env:
+        CRAFT_LOG_LEVEL: Warn
+      run: |
         targets=$(craft targets | jq -r '.[]|" - [ ] \(.)"')
 
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
@@ -96,7 +112,7 @@ runs:
         else
           subdirectory='/${{ inputs.path }}';
         fi
-        
+
         if [[ -n '${{ inputs.merge_target }}' ]]; then
           merge_target='${{ inputs.merge_target }}';
         else
@@ -115,9 +131,9 @@ runs:
         fi
 
         body="Requested by: @$GITHUB_ACTOR
-        
+
         Merge target: $merge_target
-        
+
         Quick links:
         - [View changes](https://github.com/$GITHUB_REPOSITORY/compare/${{ steps.release-git-info.outputs.last }}...${{ steps.release-git-info.outputs.branch }})
         - [View check runs](https://github.com/$GITHUB_REPOSITORY/commit/${{ steps.release-git-info.outputs.sha }}/checks/)
@@ -127,7 +143,7 @@ runs:
 
         ### Targets
 
-        ${{ steps.craft.outputs.targets }}
+        ${{ steps.craft-targets.outputs.targets }}
 
         Targets marked with a checkbox have already been executed.  Administrators can manually tick a checkbox to force craft to skip it.
         "


### PR DESCRIPTION
This PR adds a new optional input to the Prepare Release Action: `craft_config_from_merge_target`

If this option is set to `true`, the craft config for preparing the release and reading the targets from will be taken from the merge target branch (if specified) instead of from the default branch. 

By default, we keep the current behaviour, meaning craft checks out the default branch after `craft prepare` and we read the targets from the config of the default branch. 

tested run showing that the craft config is actually taken from the merge target branch: https://github.com/getsentry/publish/issues/3421

This PR is part 1 of making it possible to take the craft config from the merge target branch instead of the default branch. This will allow us to maintain multiple major versions and have diverging craft configs for these versions. Also, it unblocks JS SDK v8 releases. 