### PR TITLE
feat: Write craft config branch to issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -126,6 +126,12 @@ runs:
           merge_target='(default)';
         fi
 
+        if [[ -n '${{ inputs.craft_config_from_merge_target }}']]; then
+          config_branch="${{ inputs.merge_target }}";
+        else
+          config_branch="default";
+        fi
+
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
 
         # So, GitHub only allows search with the "in" operator and this
@@ -140,6 +146,8 @@ runs:
         body="Requested by: @$GITHUB_ACTOR
 
         Merge target: $merge_target
+
+        Craft Config from: $config_branch
 
         Quick links:
         - [View changes](https://github.com/$GITHUB_REPOSITORY/compare/${{ steps.release-git-info.outputs.last }}...${{ steps.release-git-info.outputs.branch }})

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
           merge_target='(default)';
         fi
 
-        if [[ '${{ inputs.craft_config_from_merge_target }}'  == 'true' ]]; then
+        if [[ '${{ inputs.craft_config_from_merge_target }}'  == 'true' && ${{ inputs.merge_target }} ]]; then
           config_branch='${{ inputs.merge_target }}';
         else
           config_branch='(default)';

--- a/action.yml
+++ b/action.yml
@@ -127,9 +127,9 @@ runs:
         fi
 
         if [[ '${{ inputs.craft_config_from_merge_target }}'  == 'true' && ${{ inputs.merge_target }} ]]; then
-          config_branch='${{ inputs.merge_target }}';
+          config_branch='merge_target';
         else
-          config_branch='(default)';
+          config_branch='default';
         fi
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
           merge_target='(default)';
         fi
 
-        if [[ -n '${{ inputs.craft_config_from_merge_target == 'true' }}' ]]; then
+        if [[ -n '${{ inputs.craft_config_from_merge_target }}'  == 'true' ]]; then
           config_branch='${{ inputs.merge_target }}';
         else
           config_branch='(default)';

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
           merge_target='(default)';
         fi
 
-        if [[ -n '${{ inputs.craft_config_from_merge_target }}' ]]; then
+        if [[ -n '${{ inputs.craft_config_from_merge_target == 'true' }}' ]]; then
           config_branch='${{ inputs.merge_target }}';
         else
           config_branch='(default)';

--- a/action.yml
+++ b/action.yml
@@ -126,7 +126,7 @@ runs:
           merge_target='(default)';
         fi
 
-        if [[ -n '${{ inputs.craft_config_from_merge_target }}'  == 'true' ]]; then
+        if [[ '${{ inputs.craft_config_from_merge_target }}'  == 'true' ]]; then
           config_branch='${{ inputs.merge_target }}';
         else
           config_branch='(default)';

--- a/action.yml
+++ b/action.yml
@@ -126,10 +126,10 @@ runs:
           merge_target='(default)';
         fi
 
-        if [[ -n '${{ inputs.craft_config_from_merge_target }}']]; then
-          config_branch="${{ inputs.merge_target }}";
+        if [[ -n '${{ inputs.craft_config_from_merge_target }}' ]]; then
+          config_branch='${{ inputs.merge_target }}';
         else
-          config_branch="default";
+          config_branch='(default)';
         fi
 
         title="publish: $GITHUB_REPOSITORY$subdirectory@$RELEASE_VERSION"
@@ -147,7 +147,7 @@ runs:
 
         Merge target: $merge_target
 
-        Craft Config from: $config_branch
+        Using Craft config from: $config_branch
 
         Quick links:
         - [View changes](https://github.com/$GITHUB_REPOSITORY/compare/${{ steps.release-git-info.outputs.last }}...${{ steps.release-git-info.outputs.branch }})


### PR DESCRIPTION
Our getsentry/publish `publish.yml` action takes configuration parameters from parsing the publish issue created in getsentry/publish. This PR adds the branch from which the config should be taken to the issue.

Example with custom branch: https://github.com/getsentry/publish/issues/3434
Example with default branch: https://github.com/getsentry/publish/issues/3435
Example from repo without `craft_config_from_merge_target: true`: https://github.com/getsentry/publish/issues/3440

ref: https://github.com/getsentry/publish/issues/3441