### PR TITLE
ref: Optimize merge target branch checkout step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
       if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
       shell: bash
       run: |
-        git fetch origin ${{ inputs.merge_target }}
+        git fetch origin ${{ inputs.merge_target }} --depth 1
         git checkout ${{ inputs.merge_target }}
     - name: Craft Prepare
       id: craft
@@ -88,7 +88,6 @@ runs:
       if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
       shell: bash
       run: |
-        git fetch origin ${{ inputs.merge_target }}
         git checkout ${{ inputs.merge_target }}
     - name: Read Craft Targets
       id: craft-targets


### PR DESCRIPTION
Small optimization PR for the new (optional) behaviour added in #34:

- use `--depth 1` as suggested in https://github.com/getsentry/action-prepare-release/pull/34#discussion_r1491743716
- avoid fetching the second time we check out the branch (not necessary, since we're in the same job anyway)

ref https://github.com/getsentry/publish/issues/3441