### PR TITLE
fix: Fetch entire merge target branch and tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
       if: inputs.craft_config_from_merge_target == 'true' && inputs.merge_target
       shell: bash
       run: |
-        git fetch origin ${{ inputs.merge_target }} --depth 1
+        git fetch origin ${{ inputs.merge_target }}
         git checkout ${{ inputs.merge_target }}
     - name: Craft Prepare
       id: craft


### PR DESCRIPTION
This PR reverts parts of #36 which caused tags for the merge target branch to no longer be fetched correctly. In fact, setting --depth 1 caused tags to no longer be fetched which is problematic because `craft prepare` wants to know the latest release tag on the branch. 

Failing release preparation run: https://github.com/getsentry/sentry-javascript/actions/runs/8005347523/job/21864564952#step:3:460