### PR TITLE
fix: Correctly switch to release branch when extracting git info

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,9 @@ runs:
       shell: bash
       run: |
         # craft switches back to `main` but we want info on the release branch
-        git checkout -
+        # if we previously checked out the merge target branch (craft_config_from_merge_target) 
+        # we need to go back 2 checkouts, otherwise 1
+        git checkout ${{ inputs.craft_config_from_merge_target == 'true' && inputs.merge_target && '@{-2}' || '@{-1}' }}
         echo "branch=$(git rev-parse --symbolic-full-name HEAD)" >> "$GITHUB_OUTPUT"
         echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
         echo "last=$(git rev-parse --verify "$(git describe --tags --abbrev=0)" || echo HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
In the `release-git-info` step, we previously always checked out the previous branch (`git checkout -` which TIL is a shorthand for `git checkout @{-1}`). However, if action users opted into checking out the merge target branch (`craft_config_from_merge_target`), we make an additional checkout between `craft prepare` and `release-git-info`, causing us to go back only to the merge target branch instead of the release target branch.

The consequences were that the "View Changes" and "View check runs" links were incorrect. AFAICT there were no "more serious" implications as this had no effect on the actual publishing part.

This PR changes the behaviour to checkout the second last branch (`@{-2}`) in this case and otherwise, as previously, the last branch. 

Since I don't like this syntax particularly, I considered constructing the release branch name and explicitly checking it out instead. However, users can [customize the release prefix](https://github.com/getsentry/craft/blob/8d77c38ddbe4be59f98f61b6e42952ca087d3acd/src/commands/prepare.ts#L146-L148) in their [craft config](https://github.com/getsentry/craft?tab=readme-ov-file#release-branch-name), meaning constructing the branch name would become equally (or more) complex than the -1/-2 decision. So let's go with this unless someone has a better idea.