### PR TITLE
fix: Restore working directory in "Get Release Info" step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,8 +77,8 @@ runs:
       shell: bash
       env:
         CRAFT_LOG_LEVEL: Warn
+      working-directory: ${{ inputs.path }}
       run: |
-        cd '${{ inputs.path }}'
         # Ensure we have origin/HEAD set
         git remote set-head origin --auto
         CRAFT_LOG_LEVEL=Debug craft prepare "${{ env.RELEASE_VERSION }}"
@@ -92,6 +92,7 @@ runs:
     - name: Read Craft Targets
       id: craft-targets
       shell: bash
+      working-directory: ${{ inputs.path }}
       env:
         CRAFT_LOG_LEVEL: Warn
       run: |


### PR DESCRIPTION
When working on #34 I split up the "Craft Prepare" step and missed that we `cd`'d into `inputs.path` in the original step and this was reset once we exited the step. The new "Read Craft Targets" step should also happen in the same `inputs.path` directory but it didn't anymore because the new step was missing the `cd` command.

This PR re-adds moving to the `inputs.path`. As recommended by @asottile-sentry I used the [`working-directory` option](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsstepsworking-directory) instead of the `cd` command. 