### PR TITLE
impr: Clarify how to retract

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
         - [View check runs](https://github.com/$GITHUB_REPOSITORY/commit/${{ steps.release-git-info.outputs.sha }}/checks/)
 
         Assign the **accepted** label to this issue to approve the release.
-        Leave a comment containing \`#retract\` under this issue to retract the release (original issuer only).
+        To retract the release, the person requesting it must leave a comment only containing \`#retract\` with no other text and quotes under this issue..
 
         ### Targets
 


### PR DESCRIPTION
Clarify that you must leave a comment only containing retract and nothing else to retract a release.

Related publish PR for updating the tests there https://github.com/getsentry/publish/pull/5533.